### PR TITLE
[Bugfix] Update Docker image based on CPU or GPU.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libhdf5-dev \
       openmpi-bin \
       wget && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Install ML lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.13.1-gpu-py3
+FROM python:3.10-slim
 
 ENV SHELL /bin/bash
 
@@ -16,10 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Install ML lib
-RUN pip3 install flask 
+RUN pip3 install "tensorflow[and-cuda]"
+RUN python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
+RUN pip3 install flask
 RUN pip3 install pandas 
-RUN pip3 install keras==2.1.3
-RUN pip3 install "numpy<1.17"
+RUN pip3 install "numpy<1.26"
 RUN pip3 install pillow
 RUN pip3 install requests
 RUN pip3 install flask_cors

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.10-slim
 
 ENV SHELL /bin/bash
 
-# Install system packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# install apt packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
       apt-transport-https \
       bzip2 \
       g++ \
@@ -16,15 +17,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install ML lib
-RUN pip3 install "tensorflow[and-cuda]"
-RUN python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
-RUN pip3 install flask
-RUN pip3 install pandas 
-RUN pip3 install "numpy<1.26"
-RUN pip3 install pillow
-RUN pip3 install requests
-RUN pip3 install flask_cors
+# install ml lib
+RUN pip3 install --no-cache-dir \
+    "tensorflow[and-cuda]" \
+    flask \
+    pandas \
+    "numpy<1.26" \
+    pillow \
+    requests \
+    flask_cors
 
 # Copy code.
 RUN mkdir /image-eval

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM tensorflow/tensorflow:2.14.0-gpu
 
 ENV SHELL /bin/bash
 
@@ -19,7 +19,6 @@ RUN apt-get update && \
 
 # install ml lib
 RUN pip3 install --no-cache-dir \
-    "tensorflow[and-cuda]" \
     flask \
     pandas \
     "numpy<1.26" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,20 @@ ENV SHELL /bin/bash
 # install apt packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      apt-transport-https \
-      bzip2 \
-      g++ \
-      git \
-      graphviz \
-      libgl1-mesa-glx \
-      libhdf5-dev \
-      openmpi-bin \
-      wget && \
+      apt-transport-https && \
+#       bzip2 \
+#       g++ \
+#       git \
+#       graphviz \
+#       libgl1-mesa-glx \
+#       libhdf5-dev \
+#       openmpi-bin \
+#       wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # install ml lib
+RUN pip3 install --ignore-installed blinker
 RUN pip3 install --no-cache-dir \
     flask \
     pandas \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,8 @@ RUN pip3 install --no-cache-dir \
     requests \
     flask_cors
 
-# Copy code.
-RUN mkdir /image-eval
-ADD ./ /image-eval
+# copy code
+COPY ./ /image-eval
 
 # make donwload dir
 RUN mkdir /image-eval/src/images/

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.13.1-py3
+FROM python:3.10-slim
 
 RUN apt-get update
 ENV SHELL /bin/bash
@@ -8,10 +8,12 @@ RUN apt-get install -y \
         apt-transport-https
 
 # install ml lib
+RUN pip3 install "tensorflow==2.14.0"
+RUN python3 -c "import tensorflow as tf; print(tf.reduce_sum(tf.random.normal([1000, 1000])))"
+RUN pip3 install --ignore-installed blinker # for MacOS
 RUN pip3 install flask 
 RUN pip3 install pandas 
-RUN pip3 install keras==2.1.3
-RUN pip3 install "numpy<1.17"
+RUN pip3 install "numpy<1.26"
 RUN pip3 install pillow
 RUN pip3 install requests
 RUN pip3 install flask_cors

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -1,22 +1,22 @@
 FROM python:3.10-slim
 
-RUN apt-get update
 ENV SHELL /bin/bash
 
-# install npm and python
-RUN apt-get install -y \
+# install apt packages
+RUN apt-get update && \
+    apt-get install -y \
         apt-transport-https
 
 # install ml lib
-RUN pip3 install "tensorflow==2.14.0"
-RUN python3 -c "import tensorflow as tf; print(tf.reduce_sum(tf.random.normal([1000, 1000])))"
-RUN pip3 install --ignore-installed blinker # for MacOS
-RUN pip3 install flask 
-RUN pip3 install pandas 
-RUN pip3 install "numpy<1.26"
-RUN pip3 install pillow
-RUN pip3 install requests
-RUN pip3 install flask_cors
+RUN pip3 install --ignore-installed blinker
+RUN pip3 install --no-cache-dir \
+    "tensorflow==2.14.0" \
+    flask \
+    pandas \
+    "numpy<1.26" \
+    pillow \
+    requests \
+    flask_cors
 
 # copy code.
 RUN mkdir /image-eval

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -5,7 +5,9 @@ ENV SHELL /bin/bash
 # install apt packages
 RUN apt-get update && \
     apt-get install -y \
-        apt-transport-https
+        apt-transport-https && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # install ml lib
 RUN pip3 install --ignore-installed blinker

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -19,8 +19,7 @@ RUN pip3 install --no-cache-dir \
     flask_cors
 
 # copy code.
-RUN mkdir /image-eval
-ADD ./ /image-eval
+COPY ./ /image-eval
 
 # make donwload dir
 RUN mkdir /image-eval/src/images/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker build -t wonny -f Dockerfile-cpu .
 or
 
 ```
-docker build -t wonny -f Dockerfile-gpu .
+docker build -t wonny -f Dockerfile .
 ```
 
 ## Docker run 

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -9,7 +9,7 @@ weights_file = script_path + "/weights_mobilenet_aesthetic_0.07.hdf5"
 model = MyModel('MobileNet', weights=None)
 model.build()
 model.my_model.load_weights(weights_file)
-model.my_model._make_predict_function()
+model.my_model.make_predict_function()
 
 def evaluate(images):
     # initialize data generator


### PR DESCRIPTION
### Summary
- Host machine:
  - OS: Ubuntu 22.04
  - Nvidia Driver: 535.86.05
  - CUDA: 12.2

- Update Docker image based on CPU or GPU.
   - CPU: Used `python:3.10-slim`. Installed TensorFlow via pip3 due to [compatibility issues](https://github.com/tensorflow/tensorflow/issues/52845#issuecomment-1272337911) with local M1 silicon.
   - GPU: Used `tensorflow/tensorflow:2.14.0-gpu`. Since the host machine only requires the NVIDIA® driver (the NVIDIA® CUDA® Toolkit is not required).
- Update Tensorflow2 to version [v2.14.0](https://www.tensorflow.org/install/pip#linux). (NumPy, Keras)
- Reduce Docker image size.